### PR TITLE
Add partialCached to syntax highlighting

### DIFF
--- a/src/syntaxes/hugo.tmLanguage.json
+++ b/src/syntaxes/hugo.tmLanguage.json
@@ -59,7 +59,7 @@
           "name": "constant.numeric.hugo"
         },
         {
-          "match": "\\b(block|define|else|end|if|partial|range|template|where|with)\\b",
+          "match": "\\b(block|define|else|end|if|partial|partialCached|range|template|where|with)\\b",
           "name": "keyword.control.hugo"
         },
         {


### PR DESCRIPTION
I noticed that although cached partials were added as a snippet, the keyword wasn't being highlighted. I believe that this should fix that?